### PR TITLE
Wether API の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 - 全国の詳細な天気情報を提供
   - 空に浮かぶ雲さんにとって天気予報なんてものは朝飯前だ！
   - `雲さん東京の天気教えて`
-  - ([livedoor天気情報API](http://weather.livedoor.com)を使用させていただいています。)
+  - ([livedoor天気情報代替API](http://weather.tsukumijima.net/)を使用させていただいています。)
 
 - wikipedia検索
   - 「なんでもは知らないよ。wikipediaに載ってることだけっ♡」

--- a/lib/weather.py
+++ b/lib/weather.py
@@ -4,7 +4,7 @@ import json
 # Get Weather Infomation
 # Special Thanks: @black_ichigo153
 def get_weather_information(text):
-    weather_api_url = 'http://weather.livedoor.com/forecast/webservice/json/v1'
+    weather_api_url = 'http://weather.tsukumijima.net/api/forecast'
     response_string = ''
     city_id = ''
     if text.find('長野') > -1:


### PR DESCRIPTION
#2 livedoor天気情報APIの提供終了

こんにちは
livedoor の天気情報APIが 2020年7月31日 に提供を終了していたので、
その代替APIへの切り替えをしたいと思います。

変更内容をご確認いただき、(コード, 変更ポリシー 等) 問題がなければマージしていただければと思います。

以上、よろしくお願いします。